### PR TITLE
LatticePoint Memory Optimisation and precision optimisation

### DIFF
--- a/LatticeBoltzmannCuda.cpp
+++ b/LatticeBoltzmannCuda.cpp
@@ -52,15 +52,18 @@ int main(int argc, char *argv[])
 
     for(int x = 0; x < threads.x * blocks.x * threads.y * blocks.y * threads.z * blocks.z; ++x)
     {
-      for(int i = 0; i < 27; ++i)
-      {
-          data[x].particle_distribution[i] = flowRef.particle_distribution[i];
-      }
-      for(int i = 0; i < 81; ++i)
-      {
-        data[x].reflection_weight[i] = 0.0;
-        data[x].reflection_directions[i] = 0;
-      }
+        for(int i = 0; i < 27; ++i)
+        {
+            data[x].particle_distribution[i] = flowRef.particle_distribution[i];
+        }
+        for(int i = 0; i < 81; ++i)
+        {
+            data[x].reflection_weight[i] = 0.0;
+        }
+        for(int i = 0; i < 14; ++i)
+        {
+            data[x].reflection_directions[i] = 0;
+        }
     }
 
     userLattice.load_data(data);

--- a/simulation/include/Constants.h
+++ b/simulation/include/Constants.h
@@ -3,7 +3,7 @@
 
 namespace CONSTANTS
 {
-    extern const double GEOMETRIC_TOLERANCE;
+    extern const float GEOMETRIC_TOLERANCE;
 }
 
 #endif // CONSTANTS_H

--- a/simulation/include/Geometry.h
+++ b/simulation/include/Geometry.h
@@ -7,9 +7,9 @@
 //Will need to create solution for geometry data structures
 struct Point_3
 {
-    double x, y, z;
+    float x, y, z;
 
-    Point_3(double x_i, double y_i, double z_i) : x(x_i), y(y_i), z(z_i) {};
+    Point_3(float x_i, float y_i, float z_i) : x(x_i), y(y_i), z(z_i) {};
 
     bool operator==(const Point_3& a) const
     {
@@ -20,7 +20,7 @@ struct Point_3
 
     void normaliseVector()
     {
-        double norm = sqrt((x * x) + (y * y) + (z * z));
+        float norm = sqrt((x * x) + (y * y) + (z * z));
 
         x /= norm;
         y /= norm;
@@ -28,5 +28,5 @@ struct Point_3
     }
 };
 
-Point_3 rotateVectorAroundAxis(Point_3 axis, Point_3 vector, double angle);
+Point_3 rotateVectorAroundAxis(Point_3 axis, Point_3 vector, float angle);
 #endif

--- a/simulation/include/Lattice.h
+++ b/simulation/include/Lattice.h
@@ -24,24 +24,24 @@ struct LatticeData
 
 struct FluidData
 {
-    double m_fluidDensity;
-    double m_characteristicTimescale;
+    float m_fluidDensity;
+    float m_characteristicTimescale;
 
-    FluidData(double fluidDensity, double characteristicTimescale) : m_fluidDensity(fluidDensity), m_characteristicTimescale(characteristicTimescale) {};
+    FluidData(float fluidDensity, float characteristicTimescale) : m_fluidDensity(fluidDensity), m_characteristicTimescale(characteristicTimescale) {};
     FluidData() : m_fluidDensity(1.0), m_characteristicTimescale(1.0) {};
 };
 
 struct ReflectionData
 {
-    double x = 0.0;
-    double y = 0.0;
-    double z = 0.0;
+    float x = 0.0;
+    float y = 0.0;
+    float z = 0.0;
 };
 
 class Lattice
 {
 public:
-    Lattice(int x, int y, int z, dim3 blocks, dim3 threads, FluidData fluid, double spacing);
+    Lattice(int x, int y, int z, dim3 blocks, dim3 threads, FluidData fluid, float spacing);
     ~Lattice();
 
     void load_data(LatticePoint* lattice_array);
@@ -60,13 +60,16 @@ public:
 
     void insertModel(std::string filename);
 
-    std::array<std::pair<double, int>, 27> distributeVector(Point_3 vector);
+    std::array<std::pair<float, int>, 27> distributeVector(Point_3 vector);
 
     void preProcessModel();
 
     void setFlowData(FlowData* flowData);
 
     void setReflectionData(ReflectionData* reflection);
+
+    void setReflectionDirection(LatticePoint* point, const int index, const unsigned int value);
+    int getReflectionDirection(LatticePoint* point, const int index);
 
 private:
     void createExtent();
@@ -89,7 +92,7 @@ private:
     unsigned short m_yResolution;
     unsigned short m_zResolution;
 
-    double m_latticeSpacing;
+    float m_latticeSpacing;
 
     Model* m_simModel;
 

--- a/simulation/include/LatticePoint.h
+++ b/simulation/include/LatticePoint.h
@@ -3,10 +3,9 @@
 struct LatticePoint
 {
     int x, y, z;
-    double equilibrium[27];
-    double particle_distribution[27];
+    float particle_distribution[27];
     bool isReflected;
     bool isInternal;
-    int reflection_directions[81];
-    double reflection_weight[81];
+    int reflection_directions[14];
+    float reflection_weight[81];
 };

--- a/simulation/include/Model.h
+++ b/simulation/include/Model.h
@@ -11,10 +11,10 @@
 
 #include "Geometry.h"
 
-using Meshdata = CGAL::Surface_mesh<CGAL::Simple_cartesian<double>::Point_3>;
+using Meshdata = CGAL::Surface_mesh<CGAL::Simple_cartesian<float>::Point_3>;
 
 // Will need to work on removing the headers and typedefs from this header
-typedef CGAL::Simple_cartesian<double> CoordsSystem;
+typedef CGAL::Simple_cartesian<float> CoordsSystem;
 typedef CGAL::Surface_mesh<CoordsSystem::Point_3> Mesh;
 typedef CGAL::AABB_face_graph_triangle_primitive<Mesh> Primitive;
 typedef CGAL::AABB_traits<CoordsSystem, Primitive> AABB_traits;
@@ -27,13 +27,13 @@ public:
 
     bool isModelClosed();
 
-    bool isPointInsideModel(CGAL::Simple_cartesian<double>::Point_3 point);
+    bool isPointInsideModel(CGAL::Simple_cartesian<float>::Point_3 point);
 
     const Meshdata& getMesh() const { return modelMesh; };
 
     bool checkError() { return !meshValid; };
 
-    CGAL::Simple_cartesian<double>::Iso_cuboid_3 bounding_box();
+    CGAL::Simple_cartesian<float>::Iso_cuboid_3 bounding_box();
 
     Point_3 reflectionVector(CoordsSystem::Point_3 point_1, CoordsSystem::Point_3 point_2);
 

--- a/simulation/include/SimCalcFuncs.cuh
+++ b/simulation/include/SimCalcFuncs.cuh
@@ -14,7 +14,7 @@ namespace RunCudaFunctions
 {
     void run_calculate_streaming(dim3 blocks, dim3 threads, LatticeData lattice, LatticeData templattice);
 
-    void run_calculate_collision(dim3 blocks, dim3 threads, LatticeData lattice, double timescale);
+    void run_calculate_collision(dim3 blocks, dim3 threads, LatticeData lattice, float timescale);
 
     void run_calculate_reflections(dim3 blocks, dim3 threads, LatticeData lattice, LatticeData templattice);
 

--- a/simulation/include/Utils.h
+++ b/simulation/include/Utils.h
@@ -1,0 +1,6 @@
+
+
+namespace Utils
+{
+    unsigned int compressInts(int* array, const int num, const int bitLength);
+}

--- a/simulation/source/Constants.cpp
+++ b/simulation/source/Constants.cpp
@@ -2,5 +2,5 @@
 
 namespace CONSTANTS
 {
-    const double GEOMETRIC_TOLERANCE = 1e-9;
+    const float GEOMETRIC_TOLERANCE = 1e-6;
 }

--- a/simulation/source/Geometry.cpp
+++ b/simulation/source/Geometry.cpp
@@ -4,25 +4,25 @@
 #include <math.h>
 #include <array>
 
-double calculateVectorMagnitude(Point_3& vector)
+float calculateVectorMagnitude(Point_3& vector)
 {
     return sqrt((vector.x * vector.x) + (vector.y * vector.y) + (vector.z * vector.z));
 }
 
-std::array<double, 4> quaternionMult(std::array<double, 4> vector_1, std::array<double, 4> vector_2)
+std::array<float, 4> quaternionMult(std::array<float, 4> vector_1, std::array<float, 4> vector_2)
 {
-    double r_0 = (vector_1[0] * vector_2[0]) - (vector_1[1] * vector_2[1]) - (vector_1[2] * vector_2[2]) - (vector_1[3] * vector_2[3]);
-    double r_1 = (vector_1[0] * vector_2[1]) + (vector_1[1] * vector_2[0]) + (vector_1[2] * vector_2[3]) - (vector_1[3] * vector_2[2]);
-    double r_2 = (vector_1[0] * vector_2[2]) - (vector_1[1] * vector_2[3]) + (vector_1[2] * vector_2[0]) + (vector_1[3] * vector_2[1]);
-    double r_3 = (vector_1[0] * vector_2[3]) + (vector_1[1] * vector_2[2]) - (vector_1[2] * vector_2[1]) + (vector_1[3] * vector_2[0]);
+    float r_0 = (vector_1[0] * vector_2[0]) - (vector_1[1] * vector_2[1]) - (vector_1[2] * vector_2[2]) - (vector_1[3] * vector_2[3]);
+    float r_1 = (vector_1[0] * vector_2[1]) + (vector_1[1] * vector_2[0]) + (vector_1[2] * vector_2[3]) - (vector_1[3] * vector_2[2]);
+    float r_2 = (vector_1[0] * vector_2[2]) - (vector_1[1] * vector_2[3]) + (vector_1[2] * vector_2[0]) + (vector_1[3] * vector_2[1]);
+    float r_3 = (vector_1[0] * vector_2[3]) + (vector_1[1] * vector_2[2]) - (vector_1[2] * vector_2[1]) + (vector_1[3] * vector_2[0]);
 
-    return std::array<double, 4>{r_0, r_1, r_2, r_3};
+    return std::array<float, 4>{r_0, r_1, r_2, r_3};
 }
 
-Point_3 rotateVectorAroundAxis(Point_3 axis, Point_3 vector, double angle)
+Point_3 rotateVectorAroundAxis(Point_3 axis, Point_3 vector, float angle)
 {
     {
-        double magnitude = calculateVectorMagnitude(axis);
+        float magnitude = calculateVectorMagnitude(axis);
 
         axis.x /= magnitude;
         axis.y /= magnitude;
@@ -31,12 +31,12 @@ Point_3 rotateVectorAroundAxis(Point_3 axis, Point_3 vector, double angle)
 
     angle /= 2.0;
 
-    std::array<double, 4> q{cos(angle), sin(angle) * axis.x, sin(angle) * axis.y, sin(angle) * axis.z};
-    std::array<double, 4> q_inverse{cos(-angle), sin(-angle) * axis.x, sin(-angle) * axis.y, sin(-angle) * axis.z};
+    std::array<float, 4> q{cos(angle), sin(angle) * axis.x, sin(angle) * axis.y, sin(angle) * axis.z};
+    std::array<float, 4> q_inverse{cos(-angle), sin(-angle) * axis.x, sin(-angle) * axis.y, sin(-angle) * axis.z};
 
-    std::array<double, 4> point{0.0, vector.x, vector.y, vector.z};
+    std::array<float, 4> point{0.0, vector.x, vector.y, vector.z};
 
-    std::array<double, 4> result = quaternionMult(quaternionMult(q, point), q_inverse);
+    std::array<float, 4> result = quaternionMult(quaternionMult(q, point), q_inverse);
 
     return Point_3(result[1], result[2], result[3]);
 }

--- a/simulation/source/Model.cpp
+++ b/simulation/source/Model.cpp
@@ -12,7 +12,7 @@
 
 #include "Model.h"
 
-typedef CGAL::Simple_cartesian<double> CoordsSystem;
+typedef CGAL::Simple_cartesian<float> CoordsSystem;
 typedef CGAL::Surface_mesh<CoordsSystem::Point_3> Mesh;
 typedef CGAL::AABB_face_graph_triangle_primitive<Mesh> Primitive;
 typedef CGAL::AABB_traits<CoordsSystem, Primitive> AABB_traits;
@@ -48,7 +48,7 @@ bool Model::isModelClosed()
     return CGAL::is_closed(modelMesh);
 }
 
-bool Model::isPointInsideModel(CGAL::Simple_cartesian<double>::Point_3 point)
+bool Model::isPointInsideModel(CGAL::Simple_cartesian<float>::Point_3 point)
 {
     if(!meshValid)
     {
@@ -67,7 +67,7 @@ void Model::lazyAabbTreeConstruction()
     modelTree = new AABB_tree(faces(modelMesh).first, faces(modelMesh).second, modelMesh);
 }
 
-CGAL::Simple_cartesian<double>::Iso_cuboid_3 Model::bounding_box()
+CGAL::Simple_cartesian<float>::Iso_cuboid_3 Model::bounding_box()
 {
     return CGAL::bounding_box(modelMesh.points().begin(), modelMesh.points().end());
 }

--- a/simulation/source/Utils.cpp
+++ b/simulation/source/Utils.cpp
@@ -1,0 +1,30 @@
+
+namespace Utils
+{
+    unsigned int compressInts(int* array, const int num, const int bitLength)
+    {
+        unsigned int output = 0;
+        unsigned int max = 1;
+
+        for(int bit = 0; bit < bitLength; ++bit)
+        {
+            max *= 2;
+        }
+
+        for(int i = 0; i < num - 1; ++i)
+        {
+            if(array[i] < max)
+            {
+                output = output | array[i];
+                output = output << 5;
+            }
+        }
+
+        if(array[num - 1] < max)
+        {
+            output = output | array[num - 1];
+        }
+
+        return output;
+    }
+}

--- a/test/CalculationsTest.cpp
+++ b/test/CalculationsTest.cpp
@@ -3,6 +3,7 @@
 #include <stdio.h>
 #include <cassert>
 #include <gtest/gtest.h>
+#include <bitset>
 
 #include "Lattice.h"
 #include "LatticePoint.h"
@@ -13,6 +14,7 @@
 #include "Constants.h"
 #include "FlowSurface.h"
 #include "FlowCriterion.cuh"
+#include "Utils.h"
 
 TEST(CalculationsTest, TestStreaming)
 {
@@ -39,7 +41,7 @@ TEST(CalculationsTest, TestStreaming)
 
     latticeArray = testLattice.retrieve_data();
 
-    EXPECT_NEAR(latticeArray[1].particle_distribution[5], 2.0, 1e-9);
+    EXPECT_NEAR(latticeArray[1].particle_distribution[5], 2.0, 1e-6);
 }
 
 TEST(CalculationsTest, TestCollision)
@@ -67,9 +69,9 @@ TEST(CalculationsTest, TestCollision)
 
     latticeArray = testLattice.retrieve_data();
 
-    EXPECT_NEAR(latticeArray[0].particle_distribution[0], 0.592592593, 1e-9);
-    EXPECT_NEAR(latticeArray[0].particle_distribution[1], 0.148148148, 1e-9);
-    EXPECT_NEAR(latticeArray[0].particle_distribution[2], 0.148148148, 1e-9);
+    EXPECT_NEAR(latticeArray[0].particle_distribution[0], 0.592592593, 1e-6);
+    EXPECT_NEAR(latticeArray[0].particle_distribution[1], 0.148148148, 1e-6);
+    EXPECT_NEAR(latticeArray[0].particle_distribution[2], 0.148148148, 1e-6);
 }
 
 TEST(CalculationsTest, TestFull)
@@ -97,9 +99,9 @@ TEST(CalculationsTest, TestFull)
 
     latticeArray = testLattice.retrieve_data();
     
-    EXPECT_NEAR(latticeArray[1].particle_distribution[0], -0.296296296, 1e-9);
-    EXPECT_NEAR(latticeArray[1].particle_distribution[1], -0.074074074, 1e-9);
-    EXPECT_NEAR(latticeArray[1].particle_distribution[2], 0.148148148, 1e-9);
+    EXPECT_NEAR(latticeArray[1].particle_distribution[0], -0.296296296, 1e-6);
+    EXPECT_NEAR(latticeArray[1].particle_distribution[1], -0.074074074, 1e-6);
+    EXPECT_NEAR(latticeArray[1].particle_distribution[2], 0.148148148, 1e-6);
 }
 
 TEST(CalculationsTest, TestReflections)
@@ -272,6 +274,13 @@ TEST(CalculationsTest, TestPlaneFlowGeneration)
             EXPECT_NEAR(latticeArray[point_at_coords(1, y, z)].particle_distribution[0], 0.0, 1e-6);
         }
     }
+}
+
+TEST(CalculationsTest, CompressionTest)
+{
+    int test_array[6] = {1, 2, 3, 4, 5, 6};
+
+    EXPECT_EQ(Utils::compressInts(test_array, 6, 5), 35754150);
 }
 
 int main(int argc, char **argv) {

--- a/test/CoordinatesTest.cpp
+++ b/test/CoordinatesTest.cpp
@@ -28,7 +28,7 @@ TEST(CoordinatesTest, TestLoadAndRetrieve)
 
     LatticePoint* tempLatticeArray = testLattice.retrieve_data();
 
-    EXPECT_NEAR(tempLatticeArray[0].particle_distribution[5], latticeArray[0].particle_distribution[5], 1e-9);
+    EXPECT_NEAR(tempLatticeArray[0].particle_distribution[5], latticeArray[0].particle_distribution[5], 1e-6);
 }
 
 TEST(CoordinatesTest, TestCoordsMatch)
@@ -179,11 +179,11 @@ TEST(CoordinatesTest, TestDistributeVector)
 
     Point_3 vector(1.0, 0.1, 0.1);
 
-    std::array<std::pair<double, int>, 3> expected{std::pair<double, int>{0.4134132615337746, 6}, std::pair<double, int>{0.2932933692331128, 18}, std::pair<double, int>{0.2932933692331128, 17}};
+    std::array<std::pair<float, int>, 3> expected{std::pair<float, int>{0.4134132615337746, 6}, std::pair<float, int>{0.2932933692331128, 18}, std::pair<float, int>{0.2932933692331128, 17}};
 
-    std::array<std::pair<double, int>, 27> result = testLattice.distributeVector(vector);
+    std::array<std::pair<float, int>, 27> result = testLattice.distributeVector(vector);
 
-    double norm = result[0].first + result[1].first + result[2].first;
+    float norm = result[0].first + result[1].first + result[2].first;
 
     result[0].first /= norm;
     result[1].first /= norm;
@@ -223,9 +223,9 @@ TEST(CoordinatesTest, TestReflection)
     EXPECT_NEAR(tempLatticeArray[13].reflection_weight[1*3 + 0], 0.367402, 1e-6);
     EXPECT_NEAR(tempLatticeArray[13].reflection_weight[1*3 + 1], 0.341121, 1e-6);
     EXPECT_NEAR(tempLatticeArray[13].reflection_weight[1*3 + 2], 0.291477, 1e-6);
-    EXPECT_EQ(tempLatticeArray[13].reflection_directions[1*3 + 0], 17);
-    EXPECT_EQ(tempLatticeArray[13].reflection_directions[1*3 + 1], 4);
-    EXPECT_EQ(tempLatticeArray[13].reflection_directions[1*3 + 2], 26);
+    EXPECT_EQ(testLattice.getReflectionDirection(&tempLatticeArray[13], 3), 17);
+    EXPECT_EQ(testLattice.getReflectionDirection(&tempLatticeArray[13], 4), 4);
+    EXPECT_EQ(testLattice.getReflectionDirection(&tempLatticeArray[13], 5), 26);
 }
 
 int main()

--- a/test/ModelTest.cpp
+++ b/test/ModelTest.cpp
@@ -30,11 +30,11 @@ TEST(ModelTest, isPointInsideModel)
 
     modelData.importModel("../dataFiles/cube.obj");
 
-    CGAL::Simple_cartesian<double>::Point_3 point(0.0, 0.0, 0.0);
+    CGAL::Simple_cartesian<float>::Point_3 point(0.0, 0.0, 0.0);
 
     EXPECT_TRUE(modelData.isPointInsideModel(point));
 
-    CGAL::Simple_cartesian<double>::Point_3 point_2(2.0, 0.0, 0.0);
+    CGAL::Simple_cartesian<float>::Point_3 point_2(2.0, 0.0, 0.0);
 
     EXPECT_FALSE(modelData.isPointInsideModel(point_2));
 }
@@ -54,17 +54,17 @@ TEST(ModelTest, intersectionNormal)
 
     modelData.importModel("../dataFiles/compat_cube.obj");
 
-    CGAL::Simple_cartesian<double>::Point_3 point_1(0.5, 0.5, -1.0);
-    CGAL::Simple_cartesian<double>::Point_3 point_2(0.5, 0.5,  1.0);
+    CGAL::Simple_cartesian<float>::Point_3 point_1(0.5, 0.5, -1.0);
+    CGAL::Simple_cartesian<float>::Point_3 point_2(0.5, 0.5,  1.0);
 
     Point_3 result = modelData.reflectionVector(point_1, point_2);
     Point_3 value(0.0, 0.0, -1.0);
 
-    EXPECT_NEAR(result.x, value.x, 1e-9);
-    EXPECT_NEAR(result.y, value.y, 1e-9);
-    EXPECT_NEAR(result.z, value.z, 1e-9);
+    EXPECT_NEAR(result.x, value.x, 1e-6);
+    EXPECT_NEAR(result.y, value.y, 1e-6);
+    EXPECT_NEAR(result.z, value.z, 1e-6);
 
-    point_2 = CGAL::Simple_cartesian<double>::Point_3(0.5, 0.5,  -2.0);
+    point_2 = CGAL::Simple_cartesian<float>::Point_3(0.5, 0.5,  -2.0);
 
     result = modelData.reflectionVector(point_1, point_2);
 


### PR DESCRIPTION
Optimises memory usage by compressing reflection directions, removing the saved equilibrium and dropping the precision to floats instead of doubles.