### PR TITLE
Seperate reflection data from lattice point data for memory optimisation

### DIFF
--- a/LatticeBoltzmannCuda.cpp
+++ b/LatticeBoltzmannCuda.cpp
@@ -56,14 +56,6 @@ int main(int argc, char *argv[])
         {
             data[x].particle_distribution[i] = flowRef.particle_distribution[i];
         }
-        for(int i = 0; i < 81; ++i)
-        {
-            data[x].reflection_weight[i] = 0.0;
-        }
-        for(int i = 0; i < 14; ++i)
-        {
-            data[x].reflection_directions[i] = 0;
-        }
     }
 
     userLattice.load_data(data);

--- a/simulation/include/Lattice.h
+++ b/simulation/include/Lattice.h
@@ -10,7 +10,6 @@
 #include "Geometry.h"
 #include "FlowSurface.h"
 
-class LatticePoint;
 class Model;
 
 struct LatticeData
@@ -101,4 +100,7 @@ private:
 
     ReflectionData* m_reflectionData = nullptr;
     ReflectionData* d_reflectionData;
+
+    std::vector<ReflectionValues> m_reflections;
+    ReflectionValues* d_reflections;
 };

--- a/simulation/include/LatticePoint.h
+++ b/simulation/include/LatticePoint.h
@@ -1,11 +1,17 @@
 #pragma once
 
+struct ReflectionValues
+{
+    int reflection_directions[14];
+    float reflection_weight[81];
+};
+
 struct LatticePoint
 {
     int x, y, z;
     float particle_distribution[27];
     bool isReflected;
     bool isInternal;
-    int reflection_directions[14];
-    float reflection_weight[81];
+    ReflectionValues* reflections = nullptr;
+    ReflectionValues* d_reflections = nullptr;
 };

--- a/simulation/source/SimCalcFuncs.cu
+++ b/simulation/source/SimCalcFuncs.cu
@@ -18,7 +18,7 @@ namespace CudaFunctions
         int compressedIndex = index/6;
         int compressedLoc = index % 6;
 
-        int result = point->reflection_directions[compressedIndex] & clearLookup[compressedLoc];
+        int result = point->d_reflections->reflection_directions[compressedIndex] & clearLookup[compressedLoc];
 
         result = result >> compressedLoc * 5;
         
@@ -179,13 +179,13 @@ namespace CudaFunctions
 
                 if(neighbour != nullptr)
                 {
-                    atomicAdd(&(neighbour->particle_distribution[reflection_direction]), current_point->particle_distribution[i/3] * current_point->reflection_weight[i]);
+                    atomicAdd(&(neighbour->particle_distribution[reflection_direction]), current_point->particle_distribution[i/3] * current_point->d_reflections->reflection_weight[i]);
 
                     if(reflection != nullptr)
                     {
-                        atomicAdd(&(reflection->x), (current_point->particle_distribution[i/3] * current_point->reflection_weight[i]) * ((directions[reflection_direction][0] * split[reflection_direction]) - (directions[i][0] * split[i])));
-                        atomicAdd(&(reflection->y), (current_point->particle_distribution[i/3] * current_point->reflection_weight[i]) * ((directions[reflection_direction][1] * split[reflection_direction]) - (directions[i][1] * split[i])));
-                        atomicAdd(&(reflection->z), (current_point->particle_distribution[i/3] * current_point->reflection_weight[i]) * ((directions[reflection_direction][2] * split[reflection_direction]) - (directions[i][2] * split[i])));
+                        atomicAdd(&(reflection->x), (current_point->particle_distribution[i/3] * current_point->d_reflections->reflection_weight[i]) * ((directions[reflection_direction][0] * split[reflection_direction]) - (directions[i][0] * split[i])));
+                        atomicAdd(&(reflection->y), (current_point->particle_distribution[i/3] * current_point->d_reflections->reflection_weight[i]) * ((directions[reflection_direction][1] * split[reflection_direction]) - (directions[i][1] * split[i])));
+                        atomicAdd(&(reflection->z), (current_point->particle_distribution[i/3] * current_point->d_reflections->reflection_weight[i]) * ((directions[reflection_direction][2] * split[reflection_direction]) - (directions[i][2] * split[i])));
                     }
                 }
             }

--- a/test/CoordinatesTest.cpp
+++ b/test/CoordinatesTest.cpp
@@ -220,9 +220,9 @@ TEST(CoordinatesTest, TestReflection)
 
     LatticePoint* tempLatticeArray = testLattice.retrieve_data();
 
-    EXPECT_NEAR(tempLatticeArray[13].reflection_weight[1*3 + 0], 0.367402, 1e-6);
-    EXPECT_NEAR(tempLatticeArray[13].reflection_weight[1*3 + 1], 0.341121, 1e-6);
-    EXPECT_NEAR(tempLatticeArray[13].reflection_weight[1*3 + 2], 0.291477, 1e-6);
+    EXPECT_NEAR(tempLatticeArray[13].reflections->reflection_weight[1*3 + 0], 0.367402, 1e-6);
+    EXPECT_NEAR(tempLatticeArray[13].reflections->reflection_weight[1*3 + 1], 0.341121, 1e-6);
+    EXPECT_NEAR(tempLatticeArray[13].reflections->reflection_weight[1*3 + 2], 0.291477, 1e-6);
     EXPECT_EQ(testLattice.getReflectionDirection(&tempLatticeArray[13], 3), 17);
     EXPECT_EQ(testLattice.getReflectionDirection(&tempLatticeArray[13], 4), 4);
     EXPECT_EQ(testLattice.getReflectionDirection(&tempLatticeArray[13], 5), 26);


### PR DESCRIPTION
Seperates the Reflection directions and weights from the Lattice point data. This means reflection data is only allocated for LatticePoints that are part of ther reflection calculations